### PR TITLE
fix: gpcj updates

### DIFF
--- a/.zfunc/gpcj
+++ b/.zfunc/gpcj
@@ -1,7 +1,10 @@
+#!/bin/zsh
 # GET JIRA ID
 [[ $(echo $0) == '-zsh' ]] && setopt local_options BASH_REMATCH
 REGEX="[A-Za-z]+-[0-9]+"
+PREFIX=""
 BRANCH=$(git branch --show-current)
 if [[ $BRANCH =~ $REGEX ]]; then
-   echo $BASH_REMATCH[1]
+   PREFIX=$MATCH
 fi
+echo $PREFIX

--- a/.zfunc/rfun
+++ b/.zfunc/rfun
@@ -1,0 +1,2 @@
+unfunction $1
+autoload $1


### PR DESCRIPTION
This fixes errors with using zsh instead of bash, in the future, a more extensible script could be created using this https://stackoverflow.com/questions/22537804/retrieve-a-word-after-a-regular-expression-in-shell-script but zsh works for me